### PR TITLE
Add option --base-name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ target/
 
 # pyenv
 .python-version
+
+# pycharm
+.idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.1.0 (2019-11-11)
+==================
+
+* Introduce new ``--replay-base-name`` option that lets users configure a different name of the replay file. Defaults to ``.pytest-replay``.
+
 1.0.0
 =====
 

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -28,7 +28,6 @@ def pytest_addoption(parser):
 
 
 class ReplayPlugin:
-
     def __init__(self, config):
         self.dir = config.getoption("replay_record_dir")
         self.base_script_name = config.getoption("base_name")

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
         help="Use a replay file to run the tests from that file only",
     )
     group.addoption(
-        "--base-name",
+        "--replay-base-name",
         action="store",
         dest="base_name",
         default=".pytest-replay",

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -87,14 +87,9 @@ class ReplayPlugin:
     def append_test_to_script(self, nodeid):
         suffix = "-" + self.xdist_worker_name if self.xdist_worker_name else ""
         fn = os.path.join(self.dir, self.base_script_name + suffix + self.ext)
-        flag = "a" if os.path.isfile(fn) else "w"
-        with open(fn, flag, encoding="UTF-8") as f:
+        with open(fn, "a", encoding="UTF-8") as f:
             f.write(nodeid + "\n")
             self.written_nodeids.add(nodeid)
-
-    @property
-    def suffix_sep(self):
-        return "-" if self.xdist_worker_name else ""
 
 
 def pytest_configure(config):

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -18,13 +18,20 @@ def pytest_addoption(parser):
         default=None,
         help="Use a replay file to run the tests from that file only",
     )
+    group.addoption(
+        "--base-name",
+        action="store",
+        dest="base_name",
+        default=".pytest-replay",
+        help="Base name for the output file.",
+    )
 
 
 class ReplayPlugin:
-    BASE_SCRIPT_NAME = ".pytest-replay"
 
     def __init__(self, config):
         self.dir = config.getoption("replay_record_dir")
+        self.base_script_name = config.getoption("base_name")
         if self.dir:
             self.dir = os.path.abspath(self.dir)
         nprocs = config.getoption("numprocesses", 0)
@@ -42,10 +49,10 @@ class ReplayPlugin:
             if os.path.isdir(self.dir):
                 if self.running_xdist:
                     mask = os.path.join(
-                        self.dir, self.BASE_SCRIPT_NAME + "-*" + self.ext
+                        self.dir, self.base_script_name + "-*" + self.ext
                     )
                 else:
-                    mask = os.path.join(self.dir, self.BASE_SCRIPT_NAME + self.ext)
+                    mask = os.path.join(self.dir, self.base_script_name + self.ext)
                 for fn in glob(mask):
                     os.remove(fn)
             else:
@@ -80,7 +87,7 @@ class ReplayPlugin:
 
     def append_test_to_script(self, nodeid):
         suffix = "-" + self.xdist_worker_name if self.xdist_worker_name else ""
-        fn = os.path.join(self.dir, self.BASE_SCRIPT_NAME + suffix + self.ext)
+        fn = os.path.join(self.dir, self.base_script_name + suffix + self.ext)
         flag = "a" if os.path.isfile(fn) else "w"
         with open(fn, flag, encoding="UTF-8") as f:
             f.write(nodeid + "\n")

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -20,9 +20,9 @@ def suite(testdir):
         """,
     )
 
+
 @pytest.mark.parametrize(
-    "extra_option",
-    [(None, ".pytest-replay"), ("--base-name", "NEW-BASE-NAME")]
+    "extra_option", [(None, ".pytest-replay"), ("--base-name", "NEW-BASE-NAME")]
 )
 def test_normal_execution(suite, testdir, extra_option):
     """Ensure scripts are created and the tests are executed when using --replay."""

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -22,7 +22,7 @@ def suite(testdir):
 
 
 @pytest.mark.parametrize(
-    "extra_option", [(None, ".pytest-replay"), ("--base-name", "NEW-BASE-NAME")]
+    "extra_option", [(None, ".pytest-replay"), ("--replay-base-name", "NEW-BASE-NAME")]
 )
 def test_normal_execution(suite, testdir, extra_option):
     """Ensure scripts are created and the tests are executed when using --replay."""

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -135,7 +135,3 @@ def test_cwd_changed(testdir):
     expected = ["test_cwd_changed.py::test_1\n", "test_cwd_changed.py::test_2\n"]
     assert contents == expected
     assert result.ret == 0
-
-
-def test_base_script_name():
-    pass

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -20,15 +20,24 @@ def suite(testdir):
         """,
     )
 
-
-def test_normal_execution(suite, testdir):
+@pytest.mark.parametrize(
+    "extra_option",
+    [(None, ".pytest-replay"), ("--base-name", "NEW-BASE-NAME")]
+)
+def test_normal_execution(suite, testdir, extra_option):
     """Ensure scripts are created and the tests are executed when using --replay."""
+    extra_arg, base_name = extra_option
     dir = testdir.tmpdir / "replay"
-    result = testdir.runpytest("test_1.py", f"--replay-record-dir={dir}")
+    options = ["test_1.py", f"--replay-record-dir={dir}"]
+
+    if extra_arg:
+        options.append(f"{extra_arg}={base_name}")
+
+    result = testdir.runpytest(*options)
 
     result.stdout.fnmatch_lines(f"*replay dir: {dir}")
 
-    replay_file = dir / ".pytest-replay.txt"
+    replay_file = dir / f"{base_name}.txt"
     contents = replay_file.readlines(True)
     expected = ["test_1.py::test_foo\n", "test_1.py::test_bar\n"]
     assert contents == expected
@@ -126,3 +135,7 @@ def test_cwd_changed(testdir):
     expected = ["test_cwd_changed.py::test_1\n", "test_cwd_changed.py::test_2\n"]
     assert contents == expected
     assert result.ret == 0
+
+
+def test_base_script_name():
+    pass


### PR DESCRIPTION
Add option --base-name` which allows the plugin to accept a new name for the base name of the output file.

The current behaviour of naming the file as `.pytest-replay` is preserved if the option `--base-name` is suppressed.