### PR TITLE
Changed the output format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+1.2.0 (2019-11-14)
+==================
+
+* Change the format of the output to be able to add more information. The new output has new information such as
+  start time, end time, outcome and the node identification, all these data is represented by each line being a ``json``
+  format.
+
 1.1.0 (2019-11-11)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -43,19 +43,17 @@ and a ``--replay=<file>`` can be used to re-run the tests from a previous run. F
 
     $ pytest -n auto --replay-record-dir=build/tests/replay
 
-This will generate files with the node id of each test executed by each worker, for example worker ``gw1`` will generate
-a file ``.pytest-replay-gw1.txt`` with contents like this (for pytest-replay versions <=1.1.0)::
+This will generate files with each line being a ``json`` with the following content:
+node identification, start time, end time and outcome. It is interesting to note
+that usually the node id is repeated twice, that is necessary in case of a test
+suddenly crashes we will still have the record of that test started. After the
+test finishes, ``pytest-replay`` will add another ``json`` line with the
+complete information.
+That is also useful to analyze concurrent tests which might have some kind of
+race condition and interfere in each other.
 
-    test_foo.py::test[1]
-    test_foo.py::test[3]
-    test_foo.py::test[5]
-    test_foo.py::test[7]
-    test_foo.py::test[8]
-
-Currently, ``pytest-replay`` is generating the output in a different manner as each
-line is a ``json`` with these information: node identification, start time, end time and outcome.
-That is useful to analyze concurrent tests which might have some kind of race condition.
-The new output generated is similar to::
+For example worker ``gw1`` will generate a file
+``.pytest-replay-gw1.txt`` with contents like this::
 
     {"nodeid": "test_foo.py::test[1]", "start": 0.000}
     {"nodeid": "test_foo.py::test[1]", "start": 0.000, "finish": 1.5, "outcome": "passed"}

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ and a ``--replay=<file>`` can be used to re-run the tests from a previous run. F
     $ pytest -n auto --replay-record-dir=build/tests/replay
 
 This will generate files with the node id of each test executed by each worker, for example worker ``gw1`` will generate
-a file ``.pytest-replay-gw1.txt`` with contents like this::
+a file ``.pytest-replay-gw1.txt`` with contents like this (for pytest-replay versions <=1.1.0)::
 
     test_foo.py::test[1]
     test_foo.py::test[3]
@@ -52,8 +52,25 @@ a file ``.pytest-replay-gw1.txt`` with contents like this::
     test_foo.py::test[7]
     test_foo.py::test[8]
 
+Currently, ``pytest-replay`` is generating the output in a different manner as each
+line is a ``json`` with these information: node identification, start time, end time and outcome.
+That is useful to analyze concurrent tests which might have some kind of race condition.
+The new output generated is similar to::
+
+    {"nodeid": "test_foo.py::test[1]", "start": 0.000}
+    {"nodeid": "test_foo.py::test[1]", "start": 0.000, "finish": 1.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[3]", "start": 1.5}
+    {"nodeid": "test_foo.py::test[3]", "start": 1.5, "finish": 2.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[5]", "start": 2.5}
+    {"nodeid": "test_foo.py::test[5]", "start": 2.5, "finish": 3.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[7]", "start": 3.5}
+    {"nodeid": "test_foo.py::test[7]", "start": 3.5, "finish": 4.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[8]", "start": 4.5}
+    {"nodeid": "test_foo.py::test[8]", "start": 4.5, "finish": 5.5, "outcome": "passed}
+
+
 If there is a crash or a flaky failure in the tests of the worker ``gw1``, one can take that file from the CI server and
-execute the tests in the same order with::
+execute the tests in the same order with (the old output is still supported)::
 
     $ pytest --replay=.pytest-replay-gw1.txt
 

--- a/README.rst
+++ b/README.rst
@@ -58,15 +58,15 @@ That is useful to analyze concurrent tests which might have some kind of race co
 The new output generated is similar to::
 
     {"nodeid": "test_foo.py::test[1]", "start": 0.000}
-    {"nodeid": "test_foo.py::test[1]", "start": 0.000, "finish": 1.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[1]", "start": 0.000, "finish": 1.5, "outcome": "passed"}
     {"nodeid": "test_foo.py::test[3]", "start": 1.5}
-    {"nodeid": "test_foo.py::test[3]", "start": 1.5, "finish": 2.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[3]", "start": 1.5, "finish": 2.5, "outcome": "passed"}
     {"nodeid": "test_foo.py::test[5]", "start": 2.5}
-    {"nodeid": "test_foo.py::test[5]", "start": 2.5, "finish": 3.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[5]", "start": 2.5, "finish": 3.5, "outcome": "passed"}
     {"nodeid": "test_foo.py::test[7]", "start": 3.5}
-    {"nodeid": "test_foo.py::test[7]", "start": 3.5, "finish": 4.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[7]", "start": 3.5, "finish": 4.5, "outcome": "passed"}
     {"nodeid": "test_foo.py::test[8]", "start": 4.5}
-    {"nodeid": "test_foo.py::test[8]", "start": 4.5, "finish": 5.5, "outcome": "passed}
+    {"nodeid": "test_foo.py::test[8]", "start": 4.5, "finish": 5.5, "outcome": "passed"}
 
 
 If there is a crash or a flaky failure in the tests of the worker ``gw1``, one can take that file from the CI server and

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -102,7 +102,11 @@ class ReplayPlugin:
             return
 
         with open(replay_file, "r", encoding="UTF-8") as f:
-            nodeids = {json.loads(x)["nodeid"] for x in f.readlines()}
+            all_lines = f.readlines()
+            try:
+                nodeids = {json.loads(line)["nodeid"] for line in all_lines}
+            except JSONDecodeError:
+                nodeids = {line.strip() for line in all_lines}
         remaining = []
         deselected = []
         for item in items:

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -2,7 +2,6 @@ import json
 import time
 import os
 from glob import glob
-from json import JSONDecodeError
 
 import pytest
 
@@ -97,10 +96,7 @@ class ReplayPlugin:
 
         with open(replay_file, "r", encoding="UTF-8") as f:
             all_lines = f.readlines()
-            try:
-                nodeids = {json.loads(line)["nodeid"] for line in all_lines}
-            except JSONDecodeError:
-                nodeids = {line.strip() for line in all_lines}
+            nodeids = {json.loads(line)["nodeid"] for line in all_lines}
         remaining = []
         deselected = []
         for item in items:

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -45,13 +45,7 @@ class ReplayPlugin:
         self.written_nodeids = set()
         self.cleanup_scripts()
         self.node_start_time = dict()
-        self._start_time = None
-
-    @property
-    def start_time(self):
-        if self._start_time is None:
-            self._start_time = time.time()
-        return self._start_time
+        self.start_time = config.getoption("replay_start_time")
 
     def cleanup_scripts(self):
         if self.xdist_worker_name:
@@ -135,3 +129,7 @@ def pytest_configure(config):
 def pytest_report_header(config):
     if config.getoption("replay_record_dir"):
         return "replay dir: {}".format(config.getoption("replay_record_dir"))
+
+
+def pytest_cmdline_main(config):
+    config.option.replay_start_time = time.time()

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -44,7 +44,7 @@ class ReplayPlugin:
         self.written_nodeids = set()
         self.cleanup_scripts()
         self.node_start_time = dict()
-        self.start_time = config.replay_start_time
+        self.session_start_time = config.replay_start_time
 
     def cleanup_scripts(self):
         if self.xdist_worker_name:
@@ -68,7 +68,7 @@ class ReplayPlugin:
             # only workers report running tests when running in xdist
             return
         if self.dir:
-            self.node_start_time[nodeid] = time.perf_counter() - self.start_time
+            self.node_start_time[nodeid] = time.perf_counter() - self.session_start_time
             json_content = json.dumps(
                 {"nodeid": nodeid, "start": self.node_start_time[nodeid]}
             )
@@ -83,7 +83,7 @@ class ReplayPlugin:
                 {
                     "nodeid": item.nodeid,
                     "start": self.node_start_time[item.nodeid],
-                    "finish": time.perf_counter() - self.start_time,
+                    "finish": time.perf_counter() - self.session_start_time,
                     "outcome": result.outcome,
                 }
             )

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -68,7 +68,7 @@ class ReplayPlugin:
             # only workers report running tests when running in xdist
             return
         if self.dir:
-            self.node_start_time[nodeid] = time.time() - self.start_time
+            self.node_start_time[nodeid] = time.perf_counter() - self.start_time
             json_content = json.dumps(
                 {"nodeid": nodeid, "start": self.node_start_time[nodeid]}
             )
@@ -83,7 +83,7 @@ class ReplayPlugin:
                 {
                     "nodeid": item.nodeid,
                     "start": self.node_start_time[item.nodeid],
-                    "finish": time.time() - self.start_time,
+                    "finish": time.perf_counter() - self.start_time,
                     "outcome": result.outcome,
                 }
             )
@@ -127,7 +127,7 @@ def pytest_configure(config):
     if hasattr(config, "workerinput"):
         config.replay_start_time = config.workerinput["replay_start_time"]
     else:
-        config.replay_start_time = time.time()
+        config.replay_start_time = time.perf_counter()
     if config.pluginmanager.hasplugin("xdist"):
         config.pluginmanager.register(DeferPlugin())
     if config.getoption("replay_record_dir") or config.getoption("replay_file"):

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -124,13 +124,13 @@ class DeferPlugin:
 
 
 def pytest_configure(config):
-    if hasattr(config, "workerinput"):
-        config.replay_start_time = config.workerinput["replay_start_time"]
-    else:
-        config.replay_start_time = time.perf_counter()
-    if config.pluginmanager.hasplugin("xdist"):
-        config.pluginmanager.register(DeferPlugin())
     if config.getoption("replay_record_dir") or config.getoption("replay_file"):
+        if hasattr(config, "workerinput"):
+            config.replay_start_time = config.workerinput["replay_start_time"]
+        else:
+            config.replay_start_time = time.perf_counter()
+        if config.pluginmanager.hasplugin("xdist"):
+            config.pluginmanager.register(DeferPlugin())
         config.pluginmanager.register(ReplayPlugin(config), "replay-writer")
 
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -78,6 +78,16 @@ def test_normal_execution(suite, testdir, extra_option, monkeypatch):
     result.stdout.fnmatch_lines(["test_1.py*100%*", "*= 2 passed, 2 deselected in *="])
 
 
+def test_flat_output_format(testdir, suite):
+    testdir.tmpdir.mkdir("replay")
+    file_output = testdir.tmpdir.join("replay", ".pytest-replay.txt")
+    tests_execute = ["test_1.py::test_foo", "test_1.py::test_bar"]
+    file_output.write("\n".join(tests_execute))
+    result = testdir.runpytest(f"--replay={file_output}")
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["test_1.py*100%*", "*= 2 passed, 2 deselected in *="])
+
+
 @pytest.mark.parametrize("do_crash", [True, False])
 def test_crash(testdir, do_crash):
     testdir.makepyfile(

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 
@@ -39,8 +40,21 @@ def test_normal_execution(suite, testdir, extra_option):
 
     replay_file = dir / f"{base_name}.txt"
     contents = replay_file.readlines(True)
-    expected = ["test_1.py::test_foo\n", "test_1.py::test_bar\n"]
-    assert contents == expected
+    contents = [json.loads(line.strip()) for line in contents]
+    assert contents[0] == {"nodeid": "test_1.py::test_foo", "start": 0.0}
+    assert contents[1] == {
+        "nodeid": "test_1.py::test_foo",
+        "start": 0.0,
+        "finish": 1.0,
+        "outcome": "passed",
+    }
+    assert contents[2] == {"nodeid": "test_1.py::test_bar", "start": 2.0}
+    assert contents[3] == {
+        "nodeid": "test_1.py::test_bar",
+        "start": 2.0,
+        "finish": 3.0,
+        "outcome": "passed",
+    }
     assert result.ret == 0
 
     result = testdir.runpytest(f"--replay={replay_file}")

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -53,6 +53,7 @@ def test_normal_execution(suite, testdir, extra_option, monkeypatch):
     replay_file = dir / f"{base_name}.txt"
     contents = replay_file.readlines(True)
     contents = [json.loads(line.strip()) for line in contents]
+    assert len(contents) == 4
     assert contents[0] == {"nodeid": "test_1.py::test_foo", "start": 1.0}
     assert contents[1] == {
         "nodeid": "test_1.py::test_foo",

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -33,7 +33,7 @@ def test_normal_execution(suite, testdir, extra_option, monkeypatch):
         fake_time = 0.0
 
         @classmethod
-        def time(cls):
+        def perf_counter(cls):
             cls.fake_time += 1.0
             return cls.fake_time
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -73,16 +73,6 @@ def test_normal_execution(suite, testdir, extra_option, monkeypatch):
     result.stdout.fnmatch_lines(["test_1.py*100%*", "*= 2 passed, 2 deselected in *="])
 
 
-def test_flat_output_format(testdir, suite):
-    testdir.tmpdir.mkdir("replay")
-    file_output = testdir.tmpdir.join("replay", ".pytest-replay.txt")
-    tests_execute = ["test_1.py::test_foo", "test_1.py::test_bar"]
-    file_output.write("\n".join(tests_execute))
-    result = testdir.runpytest(f"--replay={file_output}")
-    assert result.ret == 0
-    result.stdout.fnmatch_lines(["test_1.py*100%*", "*= 2 passed, 2 deselected in *="])
-
-
 @pytest.mark.parametrize("do_crash", [True, False])
 def test_crash(testdir, do_crash):
     testdir.makepyfile(

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,10 +1,6 @@
 import json
-import time
-from typing import re
 
 import pytest
-
-import pytest_replay
 
 
 @pytest.fixture

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,5 +1,10 @@
 import json
+import time
+from typing import re
+
 import pytest
+
+import pytest_replay
 
 
 @pytest.fixture
@@ -21,12 +26,24 @@ def suite(testdir):
         """,
     )
 
+class MockTime:
+    fake_time = 0.0
+    def __init__(self):
+        self.fake_time = 0.0
+
+    @classmethod
+    def time(cls):
+        cls.fake_time += 1.0
+        return cls.fake_time
 
 @pytest.mark.parametrize(
     "extra_option", [(None, ".pytest-replay"), ("--replay-base-name", "NEW-BASE-NAME")]
 )
-def test_normal_execution(suite, testdir, extra_option):
+def test_normal_execution(suite, testdir, extra_option, monkeypatch):
     """Ensure scripts are created and the tests are executed when using --replay."""
+    MockTime()
+    monkeypatch.setattr("pytest_replay.time", MockTime)
+
     extra_arg, base_name = extra_option
     dir = testdir.tmpdir / "replay"
     options = ["test_1.py", f"--replay-record-dir={dir}"]
@@ -41,22 +58,21 @@ def test_normal_execution(suite, testdir, extra_option):
     replay_file = dir / f"{base_name}.txt"
     contents = replay_file.readlines(True)
     contents = [json.loads(line.strip()) for line in contents]
-    assert contents[0] == {"nodeid": "test_1.py::test_foo", "start": 0.0}
+    assert contents[0] == {"nodeid": "test_1.py::test_foo", "start": 1.0}
     assert contents[1] == {
         "nodeid": "test_1.py::test_foo",
-        "start": 0.0,
-        "finish": 1.0,
+        "start": 1.0,
+        "finish": 2.0,
         "outcome": "passed",
     }
-    assert contents[2] == {"nodeid": "test_1.py::test_bar", "start": 2.0}
+    assert contents[2] == {"nodeid": "test_1.py::test_bar", "start": 3.0}
     assert contents[3] == {
         "nodeid": "test_1.py::test_bar",
-        "start": 2.0,
-        "finish": 3.0,
+        "start": 3.0,
+        "finish": 4.0,
         "outcome": "passed",
     }
     assert result.ret == 0
-
     result = testdir.runpytest(f"--replay={replay_file}")
     assert result.ret == 0
     result.stdout.fnmatch_lines(["test_1.py*100%*", "*= 2 passed, 2 deselected in *="])
@@ -104,11 +120,11 @@ def test_xdist(testdir):
 
     files = dir.listdir()
     assert len(files) == procs
-    test_ids = []
+    test_ids = set()
     for f in files:
-        test_ids.extend(x.strip() for x in f.readlines())
-    expected_ids = [f"test_xdist.py::test[{x}]" for x in range(10)]
-    assert sorted(test_ids) == sorted(expected_ids)
+        test_ids.update({json.loads(x.strip())["nodeid"] for x in f.readlines()})
+    expected_ids = {f"test_xdist.py::test[{x}]" for x in range(10)}
+    assert test_ids == expected_ids
 
 
 @pytest.mark.parametrize("reverse", [True, False])
@@ -145,7 +161,7 @@ def test_cwd_changed(testdir):
     dir = testdir.tmpdir / "replay"
     result = testdir.runpytest_subprocess("--replay-record-dir={}".format("replay"))
     replay_file = dir / ".pytest-replay.txt"
-    contents = replay_file.readlines(True)
-    expected = ["test_cwd_changed.py::test_1\n", "test_cwd_changed.py::test_2\n"]
+    contents = {json.loads(line)["nodeid"] for line in replay_file.readlines()}
+    expected = {"test_cwd_changed.py::test_1", "test_cwd_changed.py::test_2"}
     assert contents == expected
     assert result.ret == 0

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -23,24 +23,20 @@ def suite(testdir):
     )
 
 
-class MockTime:
-    fake_time = 0.0
-
-    def __init__(self):
-        self.fake_time = 0.0
-
-    @classmethod
-    def time(cls):
-        cls.fake_time += 1.0
-        return cls.fake_time
-
-
 @pytest.mark.parametrize(
     "extra_option", [(None, ".pytest-replay"), ("--replay-base-name", "NEW-BASE-NAME")]
 )
 def test_normal_execution(suite, testdir, extra_option, monkeypatch):
     """Ensure scripts are created and the tests are executed when using --replay."""
-    MockTime()
+
+    class MockTime:
+        fake_time = 0.0
+
+        @classmethod
+        def time(cls):
+            cls.fake_time += 1.0
+            return cls.fake_time
+
     monkeypatch.setattr("pytest_replay.time", MockTime)
 
     extra_arg, base_name = extra_option

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -26,8 +26,10 @@ def suite(testdir):
         """,
     )
 
+
 class MockTime:
     fake_time = 0.0
+
     def __init__(self):
         self.fake_time = 0.0
 
@@ -35,6 +37,7 @@ class MockTime:
     def time(cls):
         cls.fake_time += 1.0
         return cls.fake_time
+
 
 @pytest.mark.parametrize(
     "extra_option", [(None, ".pytest-replay"), ("--replay-base-name", "NEW-BASE-NAME")]


### PR DESCRIPTION
As discussed with @nicoddemus and @tadeu , I am modifying the output of the ``pytest-replay`` to write more information which might be useful when we are dealing with some tests that can interfere in each other.

the new output format is explained in the ``README.rst``, but is basically:
```
    {"nodeid": "test_foo.py::test[1]", "start": 0.000}
    {"nodeid": "test_foo.py::test[1]", "start": 0.000, "finish": 1.5, "outcome": "passed}
    {"nodeid": "test_foo.py::test[3]", "start": 1.5}
    {"nodeid": "test_foo.py::test[3]", "start": 1.5, "finish": 2.5, "outcome": "passed}
    {"nodeid": "test_foo.py::test[5]", "start": 2.5}
    {"nodeid": "test_foo.py::test[5]", "start": 2.5, "finish": 3.5, "outcome": "passed}
    {"nodeid": "test_foo.py::test[7]", "start": 3.5}
    {"nodeid": "test_foo.py::test[7]", "start": 3.5, "finish": 4.5, "outcome": "passed}
    {"nodeid": "test_foo.py::test[8]", "start": 4.5}
    {"nodeid": "test_foo.py::test[8]", "start": 4.5, "finish": 5.5, "outcome": "passed}
```