### PR TITLE
Allow to comment lines in replay file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ target/
 
 # pycharm
 .idea
+
+# example virtual env used in "Contributing"
+.env

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -96,7 +96,11 @@ class ReplayPlugin:
 
         with open(replay_file, "r", encoding="UTF-8") as f:
             all_lines = f.readlines()
-            nodeids = {json.loads(line)["nodeid"] for line in all_lines}
+            nodeids = {
+                json.loads(line)["nodeid"]
+                for line in all_lines
+                if not line.strip().startswith(('#', '//'))
+            }
         remaining = []
         deselected = []
         for item in items:


### PR DESCRIPTION
I use replay to reproduce locally errors in flaky tests that are observed in CI.
To better investigate the source of the problem is common to reduce the replay file to better invetigaste the problem.
Usually I remove all tests from the replay file that follow the test failing then (using binary search) remove tests unrelated to the failure from before.
Without this patch to search for the minimum replay it is necessary to erase some lines, run the replay, if the test stop failing than add back the removed lines and remove the others.