### PR TITLE
Add Skip Cleanup option, to avoid removing previous files before running a new command

### DIFF
--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -34,7 +34,8 @@ def pytest_addoption(parser):
         action="store_true",
         dest="skip_cleanup",
         default=False,
-        help="Skips cleanup scripts before running (does not remove previously generated replay files).",
+        help="Skips cleanup scripts before running (does not remove previously "
+        "generated replay files).",
     )
 
 

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -29,6 +29,13 @@ def pytest_addoption(parser):
         default=".pytest-replay",
         help="Base name for the output file.",
     )
+    group.addoption(
+        "--replay-skip-cleanup",
+        action="store_true",
+        dest="skip_cleanup",
+        default=False,
+        help="Skips cleanup scripts before running (does not remove previously generated replay files).",
+    )
 
 
 class ReplayPlugin:
@@ -42,7 +49,9 @@ class ReplayPlugin:
         self.xdist_worker_name = os.environ.get("PYTEST_XDIST_WORKER", "")
         self.ext = ".txt"
         self.written_nodeids = set()
-        self.cleanup_scripts()
+        skip_cleanup = config.getoption("skip_cleanup", False)
+        if not skip_cleanup:
+            self.cleanup_scripts()
         self.node_start_time = dict()
         self.session_start_time = config.replay_start_time
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -180,7 +180,7 @@ def test_skip_cleanup_does_not_erase_replay_files(suite, testdir):
         "test_2.py::test_zz",
     ]
 
-    dir = testdir.tmpdir / 'replay'
+    dir = testdir.tmpdir / "replay"
     expected = expected_node_ids[:]
     for command_line in command_lines:
         result = testdir.runpytest_subprocess(*command_line)
@@ -193,7 +193,9 @@ def test_skip_cleanup_does_not_erase_replay_files(suite, testdir):
         replay_file = dir / ".pytest-replay-gw0.txt"
         contents = [json.loads(line)["nodeid"] for line in replay_file.readlines()]
         assert contents == expected
-        expected.extend(expected_node_ids)  # Next run will expect same tests appended again.
+        expected.extend(
+            expected_node_ids
+        )  # Next run will expect same tests appended again.
 
 
 def test_cwd_changed(testdir):

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -166,6 +166,36 @@ def test_alternate_serial_parallel_does_not_erase_runs(suite, testdir, reverse):
     }
 
 
+def test_skip_cleanup_does_not_erase_replay_files(suite, testdir):
+    """--replay-skip-cleanup will not erase replay files, appending data on next run."""
+    command_lines = [
+        ("-n", "2", "--replay-record-dir=replay"),
+        ("-n", "2", "--replay-record-dir=replay", "--replay-skip-cleanup"),
+    ]
+
+    expected_node_ids = [
+        "test_1.py::test_foo",
+        "test_1.py::test_foo",
+        "test_2.py::test_zz",
+        "test_2.py::test_zz",
+    ]
+
+    dir = testdir.tmpdir / 'replay'
+    expected = expected_node_ids[:]
+    for command_line in command_lines:
+        result = testdir.runpytest_subprocess(*command_line)
+        assert result.ret == 0
+        assert set(x.basename for x in dir.listdir()) == {
+            ".pytest-replay-gw0.txt",
+            ".pytest-replay-gw1.txt",
+        }
+
+        replay_file = dir / ".pytest-replay-gw0.txt"
+        contents = [json.loads(line)["nodeid"] for line in replay_file.readlines()]
+        assert contents == expected
+        expected.extend(expected_node_ids)  # Next run will expect same tests appended again.
+
+
 def test_cwd_changed(testdir):
     """Ensure that the plugin works even if some tests changes cwd."""
     testdir.tmpdir.join("subdir").ensure(dir=1)


### PR DESCRIPTION
Useful for situations where multiple pytest calls will be made to the same replay-dir, but we don't want each run to remove the previously collected data.