### PR TITLE
Add reorder-python-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
     -   id: end-of-file-fixer
     -   id: debug-statements
     -   id: flake8
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py36-plus]
 -   repo: local
     hooks:
     -   id: rst

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 
 def read(fname):

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -1,6 +1,6 @@
 import json
-import time
 import os
+import time
 from glob import glob
 
 import pytest


### PR DESCRIPTION
This keeps imports organized automatically in a way to avoid conflicts. See [the docs](https://github.com/asottile/reorder_python_imports#why-this-style) for the rationale.