### PR TITLE
pytest-replay does not respect the order of the replay file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/psf/black
+-   repo: https://github.com/psf/black-pre-commit-mirror
     rev: 23.12.1
     hooks:
     -   id: black

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+UNRELEASED
+==========
+
+* Test execution order using ``--replay`` now follows the recorded order, not the collection order, as was always intended (`#52`_).
+
+.. _`#52`: https://github.com/ESSS/pytest-replay/pull/53
+
 1.4.0 (2021-06-09)
 ==================
 

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -106,6 +106,7 @@ class ReplayPlugin:
 
         with open(replay_file, "r", encoding="UTF-8") as f:
             all_lines = f.readlines()
+            # Use a dict to deduplicate the node ids while keeping the order.
             nodeids = dict.fromkeys(
                 json.loads(line)["nodeid"]
                 for line in all_lines

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -106,22 +106,23 @@ class ReplayPlugin:
 
         with open(replay_file, "r", encoding="UTF-8") as f:
             all_lines = f.readlines()
-            nodeids = {
+            nodeids = dict.fromkeys(
                 json.loads(line)["nodeid"]
                 for line in all_lines
                 if not line.strip().startswith(("#", "//"))
-            }
+            )
+
+        items_dict = {item.nodeid: item for item in items}
         remaining = []
-        deselected = []
-        for item in items:
-            if item.nodeid in nodeids:
+        for nodeid in nodeids:
+            if item := items_dict.pop(nodeid):
                 remaining.append(item)
-            else:
-                deselected.append(item)
+        deselected = list(items_dict.values())
 
         if deselected:
             config.hook.pytest_deselected(items=deselected)
-            items[:] = remaining
+
+        items[:] = remaining
 
     def append_test_to_script(self, nodeid, line):
         suffix = "-" + self.xdist_worker_name if self.xdist_worker_name else ""

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -117,7 +117,8 @@ class ReplayPlugin:
         remaining = []
         # Make sure to respect the order from the JSON file (#52).
         for nodeid in nodeids:
-            if item := items_dict.pop(nodeid):
+            item = items_dict.pop(nodeid)
+            if item:
                 remaining.append(item)
         deselected = list(items_dict.values())
 

--- a/src/pytest_replay/__init__.py
+++ b/src/pytest_replay/__init__.py
@@ -114,6 +114,7 @@ class ReplayPlugin:
 
         items_dict = {item.nodeid: item for item in items}
         remaining = []
+        # Make sure to respect the order from the JSON file (#52).
         for nodeid in nodeids:
             if item := items_dict.pop(nodeid):
                 remaining.append(item)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -221,6 +221,7 @@ def test_cwd_changed(testdir):
 
 @pytest.mark.usefixtures("suite")
 def test_execution_different_order(testdir):
+    """Ensure tests execute in the order defined by the JSON file, not collection (#52)."""
     dir = testdir.tmpdir / "replay"
     options = [f"--replay-record-dir={dir}"]
     result = testdir.runpytest(*options)
@@ -253,6 +254,7 @@ def test_execution_different_order(testdir):
 
 @pytest.mark.usefixtures("suite")
 def test_filter_out_tests_not_in_file(testdir):
+    """Tests not found in the JSON file should not run."""
     dir = testdir.tmpdir / "replay"
     options = [f"--replay-record-dir={dir}", "-k", "foo"]
     result = testdir.runpytest(*options)


### PR DESCRIPTION
Fixes #52

I had to update the black repo url in the pre-commit since it seems that the current one doesn't work correctly.