### PR TITLE
Refactor build to use pyproject.toml

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ UNRELEASED
 
 * Add support for Python 3.13.
 * Dropped support for EOL Python 3.8.
-
+* Change build to use pyproject.toml
 
 1.5.3
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ UNRELEASED
 
 * Add support for Python 3.13.
 * Dropped support for EOL Python 3.8.
-* Change build to use pyproject.toml
+* Change build to use ``pyproject.toml``.
 
 1.5.3
 =====

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,41 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools"]
+requires = ["setuptools>=61", "setuptools_scm"]
+
+[project]
+name = "pytest-replay"
+authors = [
+    { name = "ESSS", email = "foss@esss.co" },
+]
+dynamic = ["version"]
+license = { text = "MIT" }
+urls = { Homepage = "https://github.com/ESSS/pytest-replay" }
+description = "Saves previous test runs and allow re-execute previous pytest runs to reproduce crashes or flaky tests"
+readme = "README.rst"
+requires-python = ">=3.9"
+dependencies = [
+    "pytest",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Pytest",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Testing",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
+]
+
+[tool.setuptools]
+packages = { find = { where = ["src"] } }
+package-dir = { "" = "src" }
+
+[project.entry-points.pytest11]
+replay = "pytest_replay"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=61", "setuptools_scm"]
 
+[tool.setuptools_scm]
+
 [project]
 name = "pytest-replay"
 authors = [

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,0 @@
-from setuptools import setup
-
-
-# Please check pyproject.toml for metadata
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,49 +1,5 @@
-#!/usr/bin/env python
-import os
-
-from setuptools import find_packages
 from setuptools import setup
 
 
-def read(fname):
-    file_path = os.path.join(os.path.dirname(__file__), fname)
-    with open(file_path, encoding="utf-8") as f:
-        return f.read()
-
-
-setup(
-    name="pytest-replay",
-    author="ESSS",
-    author_email="foss@esss.co",
-    license="MIT",
-    url="https://github.com/ESSS/pytest-replay",
-    description="Saves previous test runs and allow re-execute previous pytest runs "
-    "to reproduce crashes or flaky tests",
-    long_description=read("README.rst"),
-    long_description_content_type="text/x-rst",
-    packages=find_packages(where="src"),
-    package_dir={"": "src"},
-    install_requires=["pytest"],
-    use_scm_version=True,
-    setup_requires=[
-        "setuptools_scm",
-    ],
-    python_requires=">=3.9",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Framework :: Pytest",
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Testing",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Operating System :: OS Independent",
-        "License :: OSI Approved :: MIT License",
-    ],
-    entry_points={"pytest11": ["replay = pytest_replay"]},
-)
+# Please check pyproject.toml for metadata
+setup()


### PR DESCRIPTION
Moved project metadata and configuration from setup.py to pyproject.toml to align with modern Python packaging standards. This change simplifies setup.py and ensures compatibility with tools leveraging PEP 621.